### PR TITLE
TRT-571: Ensure UMM-S record allows multiple variable subsetting.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.5.0]
 ### Changed
 - [issues/32](https://github.com/podaac/net2cog/issues/32): Added capability to support multiple variables requests, both from explicitly requesting multiple variables, or requesting "all" variables. This also partially addresses [issues/35](https://github.com/podaac/net2cog/issues/35).
 
@@ -37,6 +37,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Setup process for deploying the netcdf reformatter to SIT using Terraform deployment via Jenkins.  In order to accomplish this I setup unique terraform naming conventions for the netcdf converter while maintaining the same terraform config as l2ss.  Updated the jenkins logic to allow for SIT deployment testing. 
 
 
-[Unreleased]: https://github.com/podaac/net2cog/compare/v0.4.0...HEAD
+[Unreleased]: https://github.com/podaac/net2cog/compare/v0.5.0...HEAD
+[0.5.0]: https://github.com/podaac/net2cog/compare/v0.4.0...v0.5.0
 [0.4.0]: https://github.com/podaac/net2cog/compare/v0.3.0...v0.4.0
 [0.3.0]: https://github.com/podaac/net2cog/compare/eabb00704a6fc693aa4d79536dc5c5354c6de4d9...v0.3.0

--- a/cmr/netcdf_cmr_umm_s.json
+++ b/cmr/netcdf_cmr_umm_s.json
@@ -28,7 +28,7 @@
     ],
     "Subset": {
         "VariableSubset": {
-            "AllowMultipleValues": false
+            "AllowMultipleValues": true
         }
     }
   },


### PR DESCRIPTION
Github Issue: #32 

### Description

This PR was primarily meant to update the CHANGELOG notes and merge into `release/0.5.0`, so that I could trigger the build and publication of version `0.5.0rc1`. Then I spotted that the UMM-S record JSON was not updated to also allow multiple variables to be selected, so I included that in this PR.

Not included: changing the value of the version of the service in `pyproject.toml`. I'm not sure if I should do that, or if it gets taken care of via `poetry`.

### Overview of work done

* Changed references in `CHANGELOG.md` to be `0.5.0` instead of `Unreleased`.
* Updated the UMM-S JSON to allow multiple variables to be selected in subsetting.

### Overview of verification done

N/A - there are no code changes in the service, or the utility scripts for deployment.

### Overview of integration done

N/A - as above.

## PR checklist:

* [x] Linted (There weren't any code changes, so previous linting applies)
* ~~Updated unit tests~~
* [x] Updated changelog
* ~~Integration testing~~

_See [Pull Request Review Checklist](../CONTRIBUTING.md#reviewing) for pointers on reviewing this pull request_