### PR TITLE
issue/37: Fix CHANGELOG.md link for 0.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,7 +42,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 
 [Unreleased]: https://github.com/podaac/net2cog/compare/v0.6.0...HEAD
-[0.5.0]: https://github.com/podaac/net2cog/compare/v0.5.0...v0.6.0
+[0.6.0]: https://github.com/podaac/net2cog/compare/v0.5.0...v0.6.0
 [0.5.0]: https://github.com/podaac/net2cog/compare/v0.4.0...v0.5.0
 [0.4.0]: https://github.com/podaac/net2cog/compare/v0.3.0...v0.4.0
 [0.3.0]: https://github.com/podaac/net2cog/compare/eabb00704a6fc693aa4d79536dc5c5354c6de4d9...v0.3.0


### PR DESCRIPTION
Github Issue: #37 

### Description

This PR fixes a tiny typo in the CHANGELOG, so there's a proper link for release 0.6.0 (when it is made). Once this PR is merged, I think we then should have 0.6.0rc1 to put into UAT for testing before cutting the full release of 0.6.0.

### Overview of work done

N/A - typo fix

### Overview of verification done

I have deployed 0.6.0a2 to SIT and run the net2cog regression tests notebook, which all passed:

```
harmony-regression-tests/test$ ./run_notebooks.sh net2cog

Running regression tests
Using https://harmony.sit.earthdata.nasa.gov

Test suite net2cog starting
running test with ghcr.io/nasa/regression-tests-net2cog:latest
Waiting for net2cog.
Input Notebook:  net2cog/net2cog_Regression.ipynb
Output Notebook: /workdir/output/net2cog/Results.ipynb
Working directory: net2cog
Executing:   0%|          | 0/15 [00:00<?, ?cell/s]Executing notebook with kernel: python3
Executing: 100%|██████████| 15/15 [01:32<00:00,  6.15s/cell]
Test suite net2cog succeeded
```

### Overview of integration done

See above.

## PR checklist:

* ~~Linted~~
* ~~Updated unit tests~~
* [x] Updated changelog
* [x] Integration testing

_See [Pull Request Review Checklist](../CONTRIBUTING.md#reviewing) for pointers on reviewing this pull request_