### PR TITLE
issue/37 - Update Output Format to GEOTIFF

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.6.0]
 ### Changed
 - [issues/37](https://github.com/podaac/net2cog/issues/37): Migrated to use `xarray.DataTree`, in order to provide support for granules with hierarchical structure. This also partially addresses [issues/35](https://github.com/podaac/net2cog/issues/35).
+- [issues/37](https://github.com/podaac/net2cog/issues/37): Updated output file format in UMM-S record to "GEOTIFF", to ensure file format selection can be made in Earthdata Search.
 
 ## [0.5.0]
 ### Changed

--- a/cmr/netcdf_cmr_umm_s.json
+++ b/cmr/netcdf_cmr_umm_s.json
@@ -1,6 +1,6 @@
 {
   "Name": "net2cog",
-  "Description": "Converts NetCDF files to COG. Includes extension for running in NASA Harmony. https://github.com/podaac/net2cog",
+  "Description": "Converts NetCDF files to Cloud Optimized GeoTIFF (COG). Includes extension for running in NASA Harmony. https://github.com/podaac/net2cog",
   "Type": "Harmony",
   "URL": {
     "URLValue": "https://harmony.earthdata.nasa.gov",
@@ -21,7 +21,7 @@
     "SupportedReformattings": [
       {
         "SupportedOutputFormats": [
-          "COG"
+          "GEOTIFF"
         ],
         "SupportedInputFormat": "NETCDF-4"
       }


### PR DESCRIPTION
Github Issue: #37 

### Description

This PR makes a small adjustment to the output format specified in the net2cog UMM-S record, changing it for "COG" to "GEOTIFF". The latter option is one that Earthdata Search contains in a mapping for Harmony, to be able to display the file format in the download customisation options, and to send the MIME type along to Harmony.

### Overview of work done

Updated the UMM-S record as described.

### Overview of verification done

Have not tested as changes to UMM-S record will be published on PR merger.

### Overview of integration done

Again - no tests done due to requiring publication of record.

## PR checklist:

* [x] Linted
* ~~Updated unit tests~~
* [x] Updated changelog
* ~~Integration testing~~

_See [Pull Request Review Checklist](../CONTRIBUTING.md#reviewing) for pointers on reviewing this pull request_