### PR TITLE
Issue/12 update the CRS using information from different variable references

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Added
 ### Changed
-- [issues/46](https://github.com/podaac/net2cog/issues/46): Add support for L2 gridded and L4. This also partially addresses [issues/35](https://github.com/podaac/net2cog/issues/35).
+- [issues/46](https://github.com/podaac/net2cog/issues/46): Adds support for output of the SMAP L2 Gridding service, which has dimensions named "x-dim" and "y-dim". This also partially addresses [issues/35](https://github.com/podaac/net2cog/issues/35).
+- [issues/12](https://github.com/podaac/net2cog/issues/12): Adds support to update the CRS using information from different variable references. This also partially addresses [issues/35](https://github.com/podaac/net2cog/issues/35).
+
 ### Deprecated
 ### Removed
 ### Fixed
@@ -48,7 +50,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.2.0-alpha.11] - 11 May 2020
 ### Added
-- Setup process for deploying the netcdf reformatter to SIT using Terraform deployment via Jenkins.  In order to accomplish this I setup unique terraform naming conventions for the netcdf converter while maintaining the same terraform config as l2ss.  Updated the jenkins logic to allow for SIT deployment testing.  
+- Setup process for deploying the netcdf reformatter to SIT using Terraform deployment via Jenkins.  In order to accomplish this I setup unique terraform naming conventions for the netcdf converter while maintaining the same terraform config as l2ss.  Updated the jenkins logic to allow for SIT deployment testing.
 
 
 [Unreleased]: https://github.com/podaac/net2cog/compare/v0.6.0...HEAD

--- a/net2cog/netcdf_convert.py
+++ b/net2cog/netcdf_convert.py
@@ -21,6 +21,11 @@ from rasterio import CRS
 from rio_cogeo.cogeo import cog_translate
 from rio_cogeo.profiles import cog_profiles
 from rioxarray.exceptions import DimensionError
+from pyproj.crs import CRS as pyCRS
+from pyproj.exceptions import CRSError
+from net2cog.utilities import (
+    resolve_relative_path
+)
 
 EXCLUDE_VARS = ['lon', 'lat', 'longitude', 'latitude', 'time']
 
@@ -131,7 +136,9 @@ def _write_cogtiff(
         with rasterio.open(temp_file_name, mode='r+') as src_dataset:
             # if src_dst.crs is None:
             #     src_dst.crs = crs
-            src_dataset.crs = CRS.from_proj4(proj="+proj=latlong")
+            src_dataset.crs = get_crs_from_grid_mapping(
+                nc_xarray, variable_path, logger
+            )
             dst_profile = cog_profiles.get("deflate")
             cog_translate(
                 src_dataset,
@@ -200,6 +207,55 @@ def has_spatial_dimensions(variable: xr.DataArray | xr.DataTree) -> bool:
         or {"x", "y"}.issubset(set(variable.dims))
         or {"x-dim", "y-dim"}.issubset(set(variable.dims))
     )
+
+
+def get_crs_from_grid_mapping(
+    nc_xarray: xr.DataTree,
+    variable_path: str,
+    logger: Logger,
+) -> CRS:
+    """Check the metadata attributes for the variable to find the associated
+    grid mapping variable.  If the grid mapping variable, as referred to in the
+    grid_mapping CF-Convention metadata attribute, does not exist then
+    default to "+proj=latlong".
+
+    Parameters
+    ----------
+    nc_xarray : xarray.DataTree
+        xarray DataTree loaded from NetCDF file. This represents the whole
+        file.
+    variable_path: str
+        Full of the variable within the file to convert.
+    logger : logging.Logger
+        Python Logger object for emitting log messages.
+
+    Returns
+    -------
+    csr
+        Returns a `CRS` object corresponding to a grid mapping variable.
+
+    """
+    # Default CRS EPSG:4326
+    crs = CRS.from_proj4(proj="+proj=latlong")
+
+    try:
+        grid_mapping_attribute = nc_xarray[variable_path].attrs.get("grid_mapping")
+
+        if grid_mapping_attribute is not None:
+            cf_reference_attribute = resolve_relative_path(
+                nc_xarray, variable_path, grid_mapping_attribute, logger
+            )
+
+            if cf_reference_attribute is not None:
+                cf_parameters = nc_xarray[cf_reference_attribute].attrs
+                crs = pyCRS.from_cf(cf_parameters)
+                logger.info("CRS: %s", crs)
+    except CRSError:
+        logger.info("An unsupported target CRS. Use default CRS: %s", crs)
+    except KeyError:
+        logger.info("No variable named : %s", variable_path)
+
+    return crs
 
 
 def netcdf_converter(

--- a/net2cog/utilities.py
+++ b/net2cog/utilities.py
@@ -56,20 +56,18 @@ def resolve_relative_path(
         reference_in_group = "/".join([reference_location, reference_path])
 
         try:
-            # Attempts to access the variable, catches the exception if it does not exist
-            nc_xarray[reference_in_group]
-            resolved_path = reference_in_group
+            if nc_xarray[reference_in_group] is not None:
+                resolved_path = reference_in_group
         except KeyError:
             resolved_path = f"/{reference_path}"
 
     try:
-        # Attempts to access the variable, catches the exception if it does not exist
-        nc_xarray[resolved_path]
-        logger.info(
-            "Variable %s grid_mapping or coordinate: resolved path %s",
-            variable_path,
-            resolved_path,
-        )
+        if nc_xarray[resolved_path] is not None:
+            logger.info(
+                "Variable %s grid_mapping or coordinate: Resolved path %s",
+                variable_path,
+                resolved_path,
+            )
     except KeyError:
         logger.info(
             "Variable %s grid_mapping or coordinate: %s relative path has incorrect nesting",

--- a/net2cog/utilities.py
+++ b/net2cog/utilities.py
@@ -1,0 +1,81 @@
+# pylint: disable=unused-import
+"""
+=========
+utilties.py
+=========
+
+Utility functions for use within the net2cog service.
+"""
+
+from logging import Logger
+
+import xarray as xr
+
+
+def resolve_relative_path(
+    nc_xarray: xr.DataTree,
+    variable_path: str,
+    reference_path: str,
+    logger: Logger,
+) -> str:
+    """Given a relative path within a granule, resolve an absolute path given
+    the location of the variable making the reference. For example, a
+    variable might refer to a grid_mapping variable, or a coordinate
+    variable in the CF-Convention metadata attributes.
+
+    Finally, the resolved path is checked, to ensure it exists in the
+    DataTree. If not retrun None.
+
+    Parameters
+    ----------
+    nc_xarray : xarray.DataTree
+        xarray DataTree loaded from NetCDF file. This represents the whole
+        file.
+    variable_path: str
+        Full of the variable within the file to convert.
+    reference_path: str
+        Path of the reference (grid_mapping) attribute
+    logger : logging.Logger
+        Python Logger object for emitting log messages.
+
+    Returns
+    -------
+    str
+        Returns a path to reference attribute else None
+
+    """
+    reference_location = variable_path.rpartition("/")[0]
+
+    if reference_path.startswith("/"):
+        # If the path starts with a slash, assume it is absolute
+        resolved_path = reference_path
+    else:
+        # If a path doesn't indicate nesing, first check if there is a variable
+        # matching the name in the same group as the referee, otherwise assume
+        # the variable reference is from the root group.
+        reference_in_group = "/".join([reference_location, reference_path])
+
+        try:
+            # Attempts to access the variable, catches the exception if it does not exist
+            nc_xarray[reference_in_group]
+            resolved_path = reference_in_group
+        except KeyError:
+            resolved_path = f"/{reference_path}"
+
+    try:
+        # Attempts to access the variable, catches the exception if it does not exist
+        nc_xarray[resolved_path]
+        logger.info(
+            "Variable %s grid_mapping or coordinate: resolved path %s",
+            variable_path,
+            resolved_path,
+        )
+    except KeyError:
+        logger.info(
+            "Variable %s grid_mapping or coordinate: %s relative path has incorrect nesting",
+            variable_path,
+            reference_path,
+        )
+        resolved_path = None
+
+    return resolved_path

--- a/tests/test_crs.py
+++ b/tests/test_crs.py
@@ -1,0 +1,300 @@
+"""
+==============
+test_crs.py
+==============
+
+Test the net2cog utilites functionality.
+"""
+
+import pathlib
+import os
+from textwrap import dedent
+
+import numpy as np
+import xarray as xr
+import rasterio
+from rasterio.crs import CRS
+
+from net2cog.netcdf_convert import (
+    get_crs_from_grid_mapping,
+)
+from net2cog.utilities import (
+    resolve_relative_path
+)
+
+# Test constants
+WKT_EPSG_6933 = dedent(
+    """
+    PROJCRS["WGS 84 / NSIDC EASE-Grid 2.0 Global",
+    BASEGEOGCRS["WGS 84",
+        ENSEMBLE["World Geodetic System 1984 ensemble",
+            MEMBER["World Geodetic System 1984 (Transit)"],
+            MEMBER["World Geodetic System 1984 (G730)"],
+            MEMBER["World Geodetic System 1984 (G873)"],
+            MEMBER["World Geodetic System 1984 (G1150)"],
+            MEMBER["World Geodetic System 1984 (G1674)"],
+            MEMBER["World Geodetic System 1984 (G1762)"],
+            MEMBER["World Geodetic System 1984 (G2139)"],
+            MEMBER["World Geodetic System 1984 (G2296)"],
+            ELLIPSOID["WGS 84",6378137,298.257223563,
+                LENGTHUNIT["metre",1]],
+            ENSEMBLEACCURACY[2.0]],
+        PRIMEM["Greenwich",0,
+            ANGLEUNIT["degree",0.0174532925199433]],
+        ID["EPSG",4326]],
+    CONVERSION["US NSIDC EASE-Grid 2.0 Global",
+        METHOD["Lambert Cylindrical Equal Area",
+            ID["EPSG",9835]],
+        PARAMETER["Latitude of 1st standard parallel",30,
+            ANGLEUNIT["degree",0.0174532925199433],
+            ID["EPSG",8823]],
+        PARAMETER["Longitude of natural origin",0,
+            ANGLEUNIT["degree",0.0174532925199433],
+            ID["EPSG",8802]],
+        PARAMETER["False easting",0,
+            LENGTHUNIT["metre",1],
+            ID["EPSG",8806]],
+        PARAMETER["False northing",0,
+            LENGTHUNIT["metre",1],
+            ID["EPSG",8807]]],
+    CS[Cartesian,2],
+        AXIS["easting (X)",east,
+            ORDER[1],
+            LENGTHUNIT["metre",1]],
+        AXIS["northing (Y)",north,
+            ORDER[2],
+            LENGTHUNIT["metre",1]],
+    USAGE[
+        SCOPE["Environmental science - used as basis for EASE grid."],
+        AREA["World between 86°S and 86°N."],
+        BBOX[-86,-180,86,180]],
+    ID["EPSG",6933]]
+    """
+)
+
+WKT_EPSG_9835 = dedent(
+    """
+PROJCRS["undefined",
+    BASEGEOGCRS["undefined",
+        ENSEMBLE["World Geodetic System 1984 ensemble",
+            MEMBER["World Geodetic System 1984 (Transit)",
+                ID["EPSG",1166]],
+            MEMBER["World Geodetic System 1984 (G730)",
+                ID["EPSG",1152]],
+            MEMBER["World Geodetic System 1984 (G873)",
+                ID["EPSG",1153]],
+            MEMBER["World Geodetic System 1984 (G1150)",
+                ID["EPSG",1154]],
+            MEMBER["World Geodetic System 1984 (G1674)",
+                ID["EPSG",1155]],
+            MEMBER["World Geodetic System 1984 (G1762)",
+                ID["EPSG",1156]],
+            MEMBER["World Geodetic System 1984 (G2139)",
+                ID["EPSG",1309]],
+            MEMBER["World Geodetic System 1984 (G2296)",
+                ID["EPSG",1383]],
+            ELLIPSOID["WGS 84",6378137,298.257223563,
+                LENGTHUNIT["metre",1],
+                ID["EPSG",7030]],
+            ENSEMBLEACCURACY[2.0],
+            ID["EPSG",6326]],
+        PRIMEM["Greenwich",0,
+            ANGLEUNIT["degree",0.0174532925199433],
+            ID["EPSG",8901]]],
+    CONVERSION["unknown",
+        METHOD["Lambert Cylindrical Equal Area",
+            ID["EPSG",9835]],
+        PARAMETER["Latitude of 1st standard parallel",30,
+            ANGLEUNIT["degree",0.0174532925199433],
+            ID["EPSG",8823]],
+        PARAMETER["Longitude of natural origin",0,
+            ANGLEUNIT["degree",0.0174532925199433],
+            ID["EPSG",8802]],
+        PARAMETER["False easting",0,
+            LENGTHUNIT["metre",1],
+            ID["EPSG",8806]],
+        PARAMETER["False northing",0,
+            LENGTHUNIT["metre",1],
+            ID["EPSG",8807]]],
+    CS[Cartesian,2],
+        AXIS["(E)",east,
+            ORDER[1],
+            LENGTHUNIT["metre",1,
+                ID["EPSG",9001]]],
+        AXIS["(N)",north,
+            ORDER[2],
+            LENGTHUNIT["metre",1,
+                ID["EPSG",9001]]]]
+    """
+)
+
+
+def test_crs_nested_path_same_group(temp_dir, logger, spl2smp_nested_file):
+    """Test CRS variable with nested path same group"""
+
+    test_crs = CRS.from_wkt(WKT_EPSG_6933)
+    test_file = pathlib.Path(temp_dir, spl2smp_nested_file)
+    netcdf_file = os.path.abspath(test_file)
+    input_datatree = xr.open_datatree(netcdf_file)
+
+    # Process test file:
+    rasterio.crs = get_crs_from_grid_mapping(
+        input_datatree, "Soil_Moisture_Retrieval_Data/vegetation_water_content", logger
+    )
+
+    result_crs = rasterio.crs.to_wkt(pretty=True)
+
+    assert result_crs == test_crs
+    assert rasterio.crs.is_projected
+
+
+def test_crs_nested_path_root_group(temp_dir, logger, nested_file):
+    """Test CRS variable with nested path at root group"""
+
+    test_crs = CRS.from_wkt(WKT_EPSG_9835)
+    test_file = pathlib.Path(temp_dir, nested_file)
+    netcdf_file = os.path.abspath(test_file)
+    input_datatree = xr.open_datatree(netcdf_file)
+
+    # Process test file:
+    rasterio.crs = get_crs_from_grid_mapping(input_datatree, "NEE/nee_mean", logger)
+
+    result_crs = rasterio.crs.to_wkt(pretty=True)
+
+    assert result_crs == test_crs
+    assert rasterio.crs.is_projected
+
+
+def test_crs_multiple_variable_selection_no_grid_mapping(temp_dir, smap_file, logger):
+    """Test the default EPSG:4326 CRS variable's handling of the absence of grid
+    mapping attributes.
+
+    """
+
+    test_file = pathlib.Path(temp_dir, smap_file)
+
+    netcdf_file = os.path.abspath(test_file)
+    input_datatree = xr.open_datatree(netcdf_file)
+
+    # Process test file:
+    rasterio.crs = get_crs_from_grid_mapping(input_datatree, "sss_smap", logger)
+
+    result_crs = rasterio.crs.to_epsg()
+
+    assert result_crs == 4326
+    assert rasterio.crs.is_geographic
+
+
+def test_resolve_relative_path(logger):
+    """Ensure a relative path can be qualified to a full path using the
+    location of the dataset making the reference.
+
+    Tree structure in test:
+
+    |- science_one(lat, lon)
+    |- lat(lat)
+    |- lon(lon)
+    |- group_one
+       |- science_two(lat, lon)
+       |- science_three(lat, lon)
+       |- group_two
+          | science_four(lat, lon)
+
+    """
+    test_datatree = xr.DataTree(
+        dataset=xr.Dataset(
+            data_vars={
+                "science_one": (["lat", "lon"], np.ones((2, 3))),
+            },
+            coords={
+                "lat": ("lat", np.array([1, 2])),
+                "lon": ("lon", np.array([3, 4, 5])),
+            },
+        )
+    )
+    test_datatree["group_one"] = xr.DataTree(
+        dataset=xr.Dataset(
+            data_vars={
+                "science_two": (["lat", "lon"], np.ones((2, 3))),
+            },
+        ),
+    )
+    test_datatree["group_one"] = xr.DataTree(
+        dataset=xr.Dataset(
+            data_vars={
+                "science_three": (["lat", "lon"], np.ones((2, 3))),
+            },
+        ),
+    )
+    test_datatree["group_one/group_two"] = xr.DataTree(
+        dataset=xr.Dataset(
+            data_vars={
+                "science_four": (["lat", "lon"], np.ones((2, 3))),
+            },
+        ),
+    )
+
+    test_args = [
+        [
+            "Nested absolute path",
+            "group_one/science_two",
+            "/science_one",
+            "/science_one",
+        ],
+        [
+            "Nested relative path",
+            "group_one/science_two",
+            "science_three",
+            "group_one/science_three",
+        ],
+        [
+            "Double nested relative path",
+            "group_one/group_two/science_four",
+            "science_one",
+            "/science_one",
+        ],
+        [
+            "Double nested cross group relative path",
+            "group_one/science_two",
+            "group_one/group_two/science_four",
+            "/group_one/group_two/science_four",
+        ],
+    ]
+
+    for description, variable_path, reference_path, expected_path in test_args:
+        print(description)
+        resolved_path = resolve_relative_path(
+            test_datatree, variable_path, reference_path, logger
+        )
+
+        assert resolved_path == expected_path
+
+    # Negative test
+    test_args = [
+        [
+            "Relative path has incorrect nesting",
+            "group_one/science_two",
+            "group_one/science_four",
+            None,
+        ],
+        [
+            "Variable reference not in Datatree",
+            "group_one/science_three",
+            "science_three_half",
+            None,
+        ],
+        [
+            "Double nested cross group not in Datatree",
+            "group_one/science_two",
+            "group_one/group_two/science_two",
+            None,
+        ],
+    ]
+
+    for description, variable_path, reference_path, expected_path in test_args:
+        print(description)
+        resolved_path = resolve_relative_path(
+            test_datatree, variable_path, reference_path, logger
+        )
+
+        assert resolved_path == expected_path

--- a/tests/test_netcdf_convert.py
+++ b/tests/test_netcdf_convert.py
@@ -8,6 +8,7 @@ Test the netcdf conversion functionality.
 import pathlib
 import subprocess
 from os.path import basename, splitext
+from rio_cogeo.cogeo import cog_validate
 
 import numpy as np
 import pytest
@@ -51,6 +52,7 @@ def test_single_cog_generation(smap_file, temp_dir, logger):
 
     valid_cog = results[0] + " is a valid cloud optimized GeoTIFF"
     assert cog_test == valid_cog, 'Output COG not valid.'
+    assert cog_validate(pathlib.Path(results[0])) == (True, [], [])
 
 
 @pytest.mark.parametrize(['in_bands'], [[['gland', 'fland', 'sss_smap']]])
@@ -111,6 +113,7 @@ def test_nested_variable_selection(temp_dir, logger, nested_file):
 
     valid_cog = results[0] + ' is a valid cloud optimized GeoTIFF'
     assert cog_test == valid_cog, 'Output is not valid COG.'
+    assert cog_validate(pathlib.Path(results[0])) == (True, [], [])
 
 
 @pytest.mark.parametrize(['in_bands'], [[['waldo']]])
@@ -330,6 +333,8 @@ def test_spl2smp_nested_variable_selection(temp_dir, logger, spl2smp_nested_file
 
     valid_cog = results[0] + ' is a valid cloud optimized GeoTIFF'
     assert cog_test == valid_cog, 'Output is not valid COG.'
+
+    assert cog_validate(pathlib.Path(results[0])) == (True, [], [])
 
 
 @pytest.mark.parametrize(['in_bands'], [[['Soil_Moisture_Retrieval_Data/vegetation_opacity', 'Soil_Moisture_Retrieval_Data/vegetation_water_content']]])


### PR DESCRIPTION
Github Issue: #12 

### Description

This pull request introduces the ability to update the CRS using information from different variable references

### Overview of work done

* Add support to query grid_mapping attributes to get CRS parameters
* Add support to resolve absolute and relative path for variables within group and root directory
* Added new unit tests.

### Overview of verification done

* Added unit tests for new functions mentioned above.

### Overview of integration done

* Re-ran the [regression tests](https://github.com/nasa/harmony-regression-tests/tree/main/test/net2cog) against this version with Harmony in a Box to ensure no breakages for flat files.
* Tested against SPL4SMAU, SPL4SMGP, SPL4SMLM , SPL4CMDL, SPL2SMP_E, SPL2SMAP, SPL2SMA gridded files using attach files
* environment.yaml
* test_issue_12.py

```
$ git clone -b issue/12-crs-inputs-variations https://github.com/podaac/net2cog.git
$ cp environment.yaml test_issue_12.py net2cog/tests
$ cd net2cog/tests
$ conda env create -f ./environment.yaml && conda activate smap-l2-gridder-l4-net2cog
$ poetry run pytest -s test_netcdf_convert.py
$ poetry run pytest -s test_crs.py
$ poetry run pytest -s test_issue_12.py
```

## PR checklist:

* [x] Linted
* [x] Updated unit tests
* [x] Updated changelog
* [x] Integration testing

_See [Pull Request Review Checklist](../CONTRIBUTING.md#reviewing) for pointers on reviewing this pull request_