### PR TITLE
Issue/57 modis v7 xdim ydim

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Added
 ### Changed
-- [issues/57](https://github.com/podaac/net2cog/issues/54): Update code to support MODIS V7 variable dimension `XDim` and `YDim`.
+- [issues/57](https://github.com/podaac/net2cog/issues/54): Update code to support MODIS V7 variable dimension `XDim` and `YDim`.  Also add secondary check for CF-compliant standard_name and units if dimension name does not match.
 ### Deprecated
 ### Removed
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Added
 ### Changed
+- [issues/57](https://github.com/podaac/net2cog/issues/54): Update code to support MODIS V7 variable dimension `XDim` and `YDim`.
 ### Deprecated
 ### Removed
 ### Fixed

--- a/net2cog/netcdf_convert.py
+++ b/net2cog/netcdf_convert.py
@@ -98,7 +98,7 @@ def _write_cogtiff(
                 raise Net2CogError(
                     variable_path,
                     f'{variable_path} does not have spatial dimensions such as '
-                    'lat / lon or x / y',
+                    'lat/lon, x/y, latitude/longitude, x-dim/y-dim, or XDim/YDim',
                 )
             nc_xarray[variable_path].rio.to_raster(temp_file_name)
         except KeyError as error:

--- a/net2cog/utilities.py
+++ b/net2cog/utilities.py
@@ -362,7 +362,7 @@ def is_valid_spatial_dimensions_with_standard_name_units(
 
         if standard_name is None or units is None:
             return False
-        
+
         if standard_name not in DIM_STANDARD_NAME_AND_UNITS:
             logger.info(
                 "The standard_name [%s] for dimensions [%s] in variable: %s \

--- a/net2cog/utilities.py
+++ b/net2cog/utilities.py
@@ -21,18 +21,14 @@ DTYPE_SUPPORTED = [
     'float32',
     'float64',
 ]
-DIM_STANDARD_NAME = [
-    'projection_x_coordinate',
-    'projection_y_coordinate',
-    'longitude',
-    'latitude',
-]
-DIM_UNITS = [
-    'degrees_east',
-    'degrees_west',
-    'degrees_north',
-    'm',
-]
+DIM_STANDARD_NAME_AND_UNITS = {
+    'projection_x_coordinate': ['m', 'meters', 'meter'],
+    'projection_y_coordinate': ['m', 'meters', 'meter'],
+    'projection_x_angular_coordinate': ['m', 'meters', 'meter'],
+    'projection_y_angular_coordinate': ['m', 'meters', 'meter'],
+    'latitude': ['degrees_north', 'degree_north', 'degree_N', 'degreeN', 'degreesN'],
+    'longitude': ['degrees_east', 'degree_east', 'degree_E', 'degrees_E', 'degreeE', 'degreesE'],
+}
 
 
 class Net2CogError(Exception):
@@ -364,10 +360,24 @@ def is_valid_spatial_dimensions_with_standard_name_units(
         standard_name = coord.attrs.get('standard_name')
         units = coord.attrs.get('units')
 
-        if standard_name not in DIM_STANDARD_NAME or units not in DIM_UNITS:
+        if standard_name is None or units is None:
+            return False
+        
+        if standard_name not in DIM_STANDARD_NAME_AND_UNITS:
             logger.info(
-                "The standard_name and units dimensions [%s] for variable %s \
+                "The standard_name [%s] for dimensions [%s] in variable: %s \
                 do not comply with the CF (Climate and Forecast) conventions",
+                standard_name,
+                coord_name,
+                variable_path,
+            )
+            return False
+
+        if units not in DIM_STANDARD_NAME_AND_UNITS[standard_name]:
+            logger.info(
+                "The units [%s] for dimensions [%s] in variable: %s \
+                do not comply with the CF (Climate and Forecast) conventions",
+                units,
                 coord_name,
                 variable_path,
             )

--- a/net2cog/utilities.py
+++ b/net2cog/utilities.py
@@ -365,7 +365,7 @@ def is_valid_spatial_dimensions_with_standard_name_units(
 
         if standard_name not in DIM_STANDARD_NAME_AND_UNITS:
             logger.info(
-                "The standard_name [%s] for dimensions [%s] in variable: %s \
+                "The standard_name [%s] for coordinate [%s] in variable: %s \
                 do not comply with the CF (Climate and Forecast) conventions",
                 standard_name,
                 coord_name,
@@ -373,9 +373,9 @@ def is_valid_spatial_dimensions_with_standard_name_units(
             )
             return False
 
-        if units not in DIM_STANDARD_NAME_AND_UNITS[standard_name]:
+        if units not in DIM_STANDARD_NAME_AND_UNITS.get(standard_name, set()):
             logger.info(
-                "The units [%s] for dimensions [%s] in variable: %s \
+                "The units [%s] for coordinate [%s] in variable: %s \
                 do not comply with the CF (Climate and Forecast) conventions",
                 units,
                 coord_name,

--- a/net2cog/utilities.py
+++ b/net2cog/utilities.py
@@ -9,8 +9,8 @@ Utility functions for use within the net2cog service.
 from logging import Logger
 import xarray as xr
 
-X_COORDINATE = ("lon", "longitude", "x", "x-dim")
-Y_COORDINATE = ("lat", "latitude", "y", "y-dim")
+X_COORDINATE = ("lon", "longitude", "x", "x-dim", "XDim")
+Y_COORDINATE = ("lat", "latitude", "y", "y-dim", "YDim")
 DTYPE_SUPPORTED = [
     'ubyte',
     'uint8',
@@ -272,6 +272,7 @@ def is_valid_spatial_dimensions(
     variable: xr.DataArray | xr.DataTree, variable_path: str, logger: Logger
 ) -> bool:
     """Ensure variable has required spatial dimensions.
+    Convert the string to lowercase before performing the comparison
 
     Parameters
     ----------
@@ -292,13 +293,16 @@ def is_valid_spatial_dimensions(
             * {"longitude", "latitude"}
             * {"x", "y"}
             * {"x-dim", "y-dim"}
+            * {"XDim", "YDim"}  (Convert to lowercase before compare)
 
     """
+    variable_dims = [dim.lower() for dim in variable.dims]
     if (
-        {"lon", "lat"}.issubset(set(variable.dims))
-        or {"longitude", "latitude"}.issubset(set(variable.dims))
-        or {"x", "y"}.issubset(set(variable.dims))
-        or {"x-dim", "y-dim"}.issubset(set(variable.dims))
+        {"lon", "lat"}.issubset(set(variable_dims))
+        or {"longitude", "latitude"}.issubset(set(variable_dims))
+        or {"x", "y"}.issubset(set(variable_dims))
+        or {"x-dim", "y-dim"}.issubset(set(variable_dims))
+        or {"xdim", "ydim"}.issubset(set(variable_dims))
     ):
         return True
 

--- a/net2cog/utilities.py
+++ b/net2cog/utilities.py
@@ -21,6 +21,18 @@ DTYPE_SUPPORTED = [
     'float32',
     'float64',
 ]
+DIM_STANDARD_NAME = [
+    'projection_x_coordinate',
+    'projection_y_coordinate',
+    'longitude',
+    'latitude',
+]
+DIM_UNITS = [
+    'degrees_east',
+    'degrees_west',
+    'degrees_north',
+    'm',
+]
 
 
 class Net2CogError(Exception):
@@ -306,10 +318,59 @@ def is_valid_spatial_dimensions(
     ):
         return True
 
-    logger.info(
-        "Unable to identify spatial dimensions from [%s] for variable: %s. Skipping COG generation for this variable",
-        variable.dims,
+    # Fallback: check CF-compliant standard_name and units
+    if not is_valid_spatial_dimensions_with_standard_name_units(
+        variable,
         variable_path,
-    )
+        logger
+    ):        
+        logger.info(
+            "Unable to identify spatial dimensions from [%s] for variable: %s.\
+            Skipping COG generation for this variable",
+            variable.dims,
+            variable_path,
+        )
 
-    return False
+        return False
+
+    return True
+
+
+def is_valid_spatial_dimensions_with_standard_name_units(
+    variable: xr.DataArray | xr.DataTree, variable_path: str, logger: Logger
+) -> bool:
+    """Ensure spatial dimensions have valid CF-compliant standard_name and units.
+
+    Parameters
+    ----------
+    variable : xarray.DataArray | xarray.DataTree
+        A variable within the NetCDF-4 file, as represented in xarray.
+    variable_path: str
+        Full of the variable within the file to convert.
+    logger : logging.Logger
+        Python Logger object for emitting log messages.
+
+    Returns
+    -------
+    bool
+        True: True if all coordinate dimensions have valid standard_name and units.
+        False: otherwise.
+
+    """
+    if not variable.coords:
+        return False
+    
+    for coord_name, coord in variable.coords.items():
+        standard_name = coord.attrs.get('standard_name')
+        units = coord.attrs.get('units')
+
+        if standard_name not in DIM_STANDARD_NAME or units not in DIM_UNITS:
+            logger.info(
+                "The standard_name and units dimensions [%s] for variable %s \
+                do not comply with the CF (Climate and Forecast) conventions",
+                coord_name,
+                variable_path,
+            )
+            return False
+
+    return True

--- a/net2cog/utilities.py
+++ b/net2cog/utilities.py
@@ -323,7 +323,7 @@ def is_valid_spatial_dimensions(
         variable,
         variable_path,
         logger
-    ):        
+    ):
         logger.info(
             "Unable to identify spatial dimensions from [%s] for variable: %s.\
             Skipping COG generation for this variable",
@@ -359,7 +359,7 @@ def is_valid_spatial_dimensions_with_standard_name_units(
     """
     if not variable.coords:
         return False
-    
+
     for coord_name, coord in variable.coords.items():
         standard_name = coord.attrs.get('standard_name')
         units = coord.attrs.get('units')

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -333,9 +333,16 @@ def input_datatree_reorder_3d():
        |- science_two(latitude, longitude, time)
     |- group_two
        |- science_three(x, y, z)
-        |- group_four
+        |- group_three
           | science_four(x-dim, y-dim, z-dim)
-
+    |- group_four
+       |- science_five(abc, def, ghi)
+    |- group_five
+       |- science_six(y, x, "")
+    |- group_six
+       |- science_seven(x, y, z, w)
+    |- group_seven
+       |- science_eight(XDim, YDim, ZDim)
 
     """
     dt = xr.DataTree(
@@ -421,6 +428,19 @@ def input_datatree_reorder_3d():
                 "x": ("x", np.array([3, 4])),
                 "z": ("z", np.array([5, 6])),
                 "w": ("w", np.array([7, 8])),
+            },
+        )
+    )
+
+    dt["group_seven"] = xr.DataTree(
+        dataset=xr.Dataset(
+            data_vars={
+                "science_eight": (["XDim", "YDim", "ZDim"], np.ones((2, 2, 2))),
+            },
+            coords={
+                "XDim": ("XDim", np.array([1, 2])),
+                "YDim": ("YDim", np.array([3, 4])),
+                "ZDim": ("ZDim", np.array([5, 6])),
             },
         )
     )
@@ -525,6 +545,88 @@ def input_datatree_reorder_2d_x_dim_y_dim():
             coords={
                 "x-dim": ("x-dim", np.array([1, 2])),
                 "y-dim": ("y-dim", np.array([3, 4, 5])),
+            },
+        ),
+    )
+
+    return dt
+
+
+@fixture()
+def input_datatree_2d_XDim_YDim():
+    """Build 2 dimension XDim, YDim Datatree to verify tests.
+
+    Tree structure in test:
+
+    |- science_one(XDim, YDim)
+    |- XDim
+    |- YDim
+    |- group_one
+       |- science_two(xDim, yDim)
+    |- group_two
+       |- science_three(Xdim, Ydim)
+    |- group_three
+       |- science_four(XDIM, YDIM)
+    |- group_four
+       |- science_five(xdim, ydim)
+
+    """
+    dt = xr.DataTree(
+        dataset=xr.Dataset(
+            data_vars={
+                "science_one": (["XDim", "YDim"], np.ones((2, 3))),
+            },
+            coords={
+                "XDim": ("XDim", np.array([1, 2])),
+                "YDim": ("YDim", np.array([3, 4, 5])),
+            },
+        ),
+    )
+
+    dt["group_one"] = xr.DataTree(
+        dataset=xr.Dataset(
+            data_vars={
+                "science_two": (["xDim", "yDim"], np.ones((2, 3))),
+            },
+            coords={
+                "xDim": ("xDim", np.array([1, 2])),
+                "yDim": ("yDim", np.array([3, 4, 5])),
+            },
+        ),
+    )
+
+    dt["group_two"] = xr.DataTree(
+        dataset=xr.Dataset(
+            data_vars={
+                "science_three": (["Xdim", "Ydim"], np.ones((2, 3))),
+            },
+            coords={
+                "Xdim": ("Xdim", np.array([1, 2])),
+                "Ydim": ("Ydim", np.array([3, 4, 5])),
+            },
+        ),
+    )
+
+    dt["group_three"] = xr.DataTree(
+        dataset=xr.Dataset(
+            data_vars={
+                "science_four": (["XDIM", "YDIM"], np.ones((2, 3))),
+            },
+            coords={
+                "XDIM": ("XDIM", np.array([1, 2])),
+                "YDIM": ("YDIM", np.array([3, 4, 5])),
+            },
+        ),
+    )
+
+    dt["group_four"] = xr.DataTree(
+        dataset=xr.Dataset(
+            data_vars={
+                "science_five": (["xdim", "ydim"], np.ones((2, 3))),
+            },
+            coords={
+                "xdim": ("xdim", np.array([1, 2])),
+                "ydim": ("ydim", np.array([3, 4, 5])),
             },
         ),
     )

--- a/tests/test_netcdf_convert.py
+++ b/tests/test_netcdf_convert.py
@@ -115,7 +115,7 @@ def test_non_spatial_variable_fails(temp_dir, logger, nested_file):
     test_file = pathlib.Path(temp_dir, nested_file)
     expected_exception = (
         'EASE2_global_projection does not have spatial dimensions '
-        'such as lat / lon or x / y'
+        'such as lat/lon, x/y, latitude/longitude, x-dim/y-dim, or XDim/YDim'
     )
 
     with pytest.raises(Net2CogError, match=expected_exception):

--- a/tests/test_utilites.py
+++ b/tests/test_utilites.py
@@ -323,6 +323,31 @@ def test_reorder_2d_x_dim_y_dim(input_datatree_reorder_2d_x_dim_y_dim):
     assert nc_xarray_tmp[variable_path].dims == expected_path
 
 
+def test_reorder_2d_XDim_YDim(input_datatree_2d_XDim_YDim):
+    """Ensure that a 2-dimensional XDim YDim array is reordered using
+    DataTree.transpose() to create the correct dimension
+    order in a new DataTree
+
+    Tree structure in input_datatree:
+
+    |- science_five(XDim, YDim)
+    |- XDim
+    |- YDim
+
+    """
+
+    description = "Test reordered (XDim, YDim) to (YDim, XDim)"
+    variable_path = "science_one"
+    expected_path = ("YDim", "XDim")
+
+    print(description)
+    nc_xarray_tmp = reorder_dimensions(
+        input_datatree_2d_XDim_YDim, variable_path
+    )
+
+    assert nc_xarray_tmp[variable_path].dims == expected_path
+
+
 def test_reorder_3d_dimensions(input_datatree_reorder_3d):
     """Ensure that a 3-dimensional array is reordered using
     DataTree.transpose() to create the correct dimension
@@ -342,6 +367,8 @@ def test_reorder_3d_dimensions(input_datatree_reorder_3d):
           | science_four(x-dim, y-dim, z-dim)
     |- group_four
        |- science_five(abc, def, ghi)
+    |- group_seven
+       |- science_eight(XDim, YDim, ZDim)
 
     """
 
@@ -365,6 +392,11 @@ def test_reorder_3d_dimensions(input_datatree_reorder_3d):
             "Test reordered (x-dim, y-dim, z-dim) to (z-dim, y-dim, x-dim)",
             "group_two/group_three/science_four",
             ("z-dim", "y-dim", "x-dim"),
+        ],
+        [
+            "Test reordered (XDim, YDim, ZDim) to (ZDim, YDim, XDim)",
+            "group_seven/science_eight",
+            ("ZDim", "YDim", "XDim"),
         ],
     ]
 
@@ -426,7 +458,8 @@ def test_reorder_3d_dimensions_exception(input_datatree_reorder_3d):
 
 @pytest.mark.parametrize(
     'dimensions',
-    [['lat', 'lon'], ['latitude', 'longitude'], ['x', 'y'], ['x-dim', 'y-dim']],
+    [['lat', 'lon'], ['latitude', 'longitude'], ['x', 'y'], ['x-dim', 'y-dim'],
+     ['XDim', 'YDim']],
 )
 def test_is_valid_spatial_dimensions_present(dimensions, logger):
     """Verify returns True for variable with spatial dimensions."""
@@ -444,7 +477,8 @@ def test_is_valid_spatial_dimensions_present(dimensions, logger):
 
 @pytest.mark.parametrize(
     'dimensions',
-    [['lat', 'lon'], ['latitude', 'longitude'], ['x', 'y'], ['x-dim', 'y-dim']],
+    [['lat', 'lon'], ['latitude', 'longitude'], ['x', 'y'], ['x-dim', 'y-dim'],
+     ['XDim', 'YDim']],
 )
 def test_is_valid_spatial_dimensions_and_others_present(dimensions, logger):
     """Verify returns True, when spatial dimensions and others are present."""
@@ -474,6 +508,7 @@ def test_is_valid_spatial_dimensions_incomplete(dimension, logger):
             },
         ),
     )
+    print(f'Test variable.dim returns False when only one spatial dimension present')
     assert not is_valid_spatial_dimensions(test_datatree['science'], 'science', logger)
 
 
@@ -484,6 +519,70 @@ def test_is_valid_spatial_dimensions_absent(logger):
             data_vars={'science': (['time'], np.ones(4))},
             coords={
                 'time': ('time', np.array([1, 2, 3, 4])),
+            },
+        ),
+    )
+    print(f'For variables (time) that do not have spatial dimensions, test returns False')
+    assert not is_valid_spatial_dimensions(test_datatree['science'], 'science', logger)
+
+
+def test_is_valid_spatial_dimensions_XDim_YDim(input_datatree_2d_XDim_YDim, logger):
+    """erify returns True, when spatial dimensions and others are present.
+    
+        |- science_one(XDim, YDim)
+        |- XDim
+        |- YDim
+        |- group_one
+            |- science_two(xDim, yDim)
+        |- group_two
+            |- science_three(Xdim, Ydim)
+        |- group_three
+            |- science_four(XDIM, YDIM)
+        |- group_four
+            |- science_five(xdim, ydim)
+
+    """
+    test_args = [
+        [
+            "Test XDim/YDim is valid spatial dimensions",
+            "science_one",
+            ("XDim", "YDim"),
+        ],
+        [
+            "Test xDim/yDim is valid spatial dimensions",
+            "group_one/science_two",
+            ("xDim", "yDim"),
+        ],
+        [
+            "Test xDim/yDim is valid spatial dimensions",
+            "group_two/science_three",
+            ("Xdim", "Ydim"),
+        ],
+        [
+            "Test XDIM/YDIM is valid spatial dimensions",
+            "group_three/science_four",
+            ("XDIM", "YDIM"),
+        ],
+        [
+            "Test xdim/ydim is valid spatial dimensions",
+            "group_four/science_five",
+            ("xdim", "ydim"),
+        ],
+    ]
+
+    for description, variable_path, expected_path in test_args:
+        print(description)
+        assert is_valid_spatial_dimensions(input_datatree_2d_XDim_YDim, variable_path, logger)
+
+
+@pytest.mark.parametrize('dimension', ['XDim', 'y-dim'])
+def test_is_valid_spatial_dimensions_XDim_y_dim_incomplete(dimension, logger):
+    """Verify returns False when only one spatial dimension present."""
+    test_datatree = xr.DataTree(
+        dataset=xr.Dataset(
+            data_vars={'science': ([dimension], np.ones((4)))},
+            coords={
+                dimension: (dimension, np.array([1, 2, 3, 4])),
             },
         ),
     )

--- a/tests/test_utilites.py
+++ b/tests/test_utilites.py
@@ -15,6 +15,7 @@ from net2cog.utilities import (
     is_variable_in_datatree,
     reorder_dimensions,
     is_valid_spatial_dimensions,
+    is_valid_spatial_dimensions_with_standard_name_units,
 )
 
 
@@ -527,7 +528,7 @@ def test_is_valid_spatial_dimensions_absent(logger):
 
 
 def test_is_valid_spatial_dimensions_XDim_YDim(input_datatree_2d_XDim_YDim, logger):
-    """erify returns True, when spatial dimensions and others are present.
+    """Verify returns True, when spatial dimensions and others are present.
     
         |- science_one(XDim, YDim)
         |- XDim
@@ -587,3 +588,96 @@ def test_is_valid_spatial_dimensions_XDim_y_dim_incomplete(dimension, logger):
         ),
     )
     assert not is_valid_spatial_dimensions(test_datatree['science'], 'science', logger)
+
+
+def test_is_valid_spatial_dimensions_with_invalid_dim_names_with_valid_standard_name_units_success(logger):
+    """Verify returns True, when spatial dimensions has invalid dim name 'latlat' and 'lonlong
+    with correct standard_name and units."""
+    coords = {
+        "latlat": xr.DataArray([0], attrs={"standard_name": "latitude", "units": "degrees_north"}),
+        "lonlon": xr.DataArray([0], attrs={"standard_name": "longitude", "units": "degrees_east"})
+    }
+    variable = xr.DataArray([1], coords=coords)
+    assert is_valid_spatial_dimensions(variable, "science", logger)
+
+
+def test_is_valid_spatial_dimensions_with_standard_name_units_success_lat_lon(logger):
+    """Verify returns True, when spatial dimensions has correct standard_name and units."""
+    coords = {
+        "lat": xr.DataArray([0], attrs={"standard_name": "latitude", "units": "degrees_north"}),
+        "lon": xr.DataArray([0], attrs={"standard_name": "longitude", "units": "degrees_east"})
+    }
+    variable = xr.DataArray([1], coords=coords)
+    assert is_valid_spatial_dimensions_with_standard_name_units(variable, "science", logger)
+
+
+def test_is_valid_spatial_dimensions_with_standard_name_units_success_xdim_ydim(logger):
+    """Verify returns True, when spatial dimensions has correct standard_name and units."""
+    coords = {
+        "XDim": xr.DataArray([0], attrs={"standard_name": "projection_x_coordinate", "units": "m"}),
+        "YDim": xr.DataArray([0], attrs={"standard_name": "projection_y_coordinate", "units": "m"})
+    }
+    variable = xr.DataArray([1], coords=coords)
+    assert is_valid_spatial_dimensions_with_standard_name_units(variable, "science", logger)
+
+
+def test_invalid_spatial_dimensions_with_standard_name_units_success_time(logger):
+    """Verify returns False, when spatial dimensions has standard_name 'time' and units ' since '."""
+    coords = {
+        "lat": xr.DataArray([0], attrs={"standard_name": "latitude", "units": "degrees_north"}),
+        "lon": xr.DataArray([0], attrs={"standard_name": "longitude", "units": "degrees_east"}),
+        "time": xr.DataArray([0], attrs={"standard_name": "time", "units": "hours since 2001-01-01 00:00:00.0"})
+    }
+    variable = xr.DataArray([1], coords=coords)
+    assert is_valid_spatial_dimensions_with_standard_name_units(variable, "science", logger) is False
+
+
+def test_missing_standard_name(logger):
+    """Verify returns False, when spatial dimensions does not have standard_name."""
+    coords = {
+        "lat": xr.DataArray([0], attrs={"units": "degrees_north"}),
+        "lon": xr.DataArray([0], attrs={"standard_name": "longitude", "units": "degrees_east"})
+    }
+    variable = xr.DataArray([1], coords=coords)
+
+    assert is_valid_spatial_dimensions_with_standard_name_units(variable, "science", logger) is False
+
+
+def test_missing_units(logger):
+    """Verify returns False, when spatial dimensions does not have standard_name."""
+    coords = {
+        "lat": xr.DataArray([0], attrs={"standard_name": "latitude", "units": "degrees_north"}),
+        "lon": xr.DataArray([0], attrs={"standard_name": "longitude"})
+    }
+    variable = xr.DataArray([1], coords=coords)
+
+    assert is_valid_spatial_dimensions_with_standard_name_units(variable, "science", logger) is False
+
+
+def test_invalid_standard_name(logger):
+    """Verify returns False, when spatial dimensions have invalid units."""
+    coords = {
+        "lat": xr.DataArray([0], attrs={"standard_name": "lat", "units": "degrees_north"}),
+        "lon": xr.DataArray([0], attrs={"standard_name": "longitude", "units": "degrees_east"})
+    }
+    variable = xr.DataArray([1], coords=coords)
+
+    assert is_valid_spatial_dimensions_with_standard_name_units(variable, "science", logger) is False
+
+
+def test_invalid_units(logger):
+    """Verify returns False, when spatial dimensions have invalid units."""
+    coords = {
+        "lat": xr.DataArray([0], attrs={"standard_name": "latitude", "units": "radians"}),
+        "lon": xr.DataArray([0], attrs={"standard_name": "longitude", "units": "degrees_east"})
+    }
+    variable = xr.DataArray([1], coords=coords)
+
+    assert is_valid_spatial_dimensions_with_standard_name_units(variable, "science", logger) is False
+
+
+def test_empty_coords(logger):
+    """Verify returns False, when spatial dimensions have empty coordinates."""
+    variable = xr.DataArray([1])
+
+    assert is_valid_spatial_dimensions_with_standard_name_units(variable, "science", logger) is False


### PR DESCRIPTION
Github Issue: #57

### Description

This pull request adds support MODIS V7 variable dimension `XDim` and `YDim`.  Also add secondary check for CF-compliant standard_name and units if dimension name does not match.


### Overview of work done

* Add check for `XDim` and `YDim` dimension variables
* Add secondary check for CF-compliant standard_name and units if dimension variables does not match 
* Added new unit tests.

### Overview of verification done

* Added unit tests for new functions mentioned above.

### Overview of integration done
* Download environment.yaml from attachment to 
[environment.yaml](https://github.com/user-attachments/files/22369832/environment.yaml)

```
$ git clone -b issue/57-modis-v7-xdim-ydim https://github.com/podaac/net2cog.git
$ cd net2cog/tests
Download environment.yaml from attachment to net2cog/tests
$ conda env create -f ./environment.yaml && conda activate net2cog_tests
$ poetry run pytest -s test_netcdf_convert.py
$ poetry run pytest -s test_crs.py
$ poetry run pytest -s test_utilites.py
```

- Start Dockers
```
% poetry build
% docker build -f docker/Dockerfile -t ghcr.io/podaac/net2cog:SIT --build-arg SOURCE="dist/net2cog-1.1.0a2-py3-none-any.whl[harmony]" --build-arg DIST_PATH="dist/" .
```
* Re-ran the [regression tests](https://github.com/nasa/harmony-regression-tests/tree/main/test/net2cog) against this version with Harmony in a Box using (harmony_host_url = 'http://localhost:3000') to ensure no breakages for flat files.

## PR checklist:

* [x] Linted
* [x] Updated unit tests
* [x] Updated changelog
* [x] Integration testing

_See [Pull Request Review Checklist](../CONTRIBUTING.md#reviewing) for pointers on reviewing this pull request_