### PR TITLE
issue/87: Added support for BigTIFF output if necessary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Added
+- [issue/87](https://github.com/podaac/net2cog/issues/86): Added support for Big TIFF outputs if the input raster is determined to be sufficiently large (>4.6 GB)
 ### Changed
 - [issue/72](https://github.com/podaac/net2cog/issues/72): Empty results that would previously log a message now throw a service error
 - [issue/86](https://github.com/podaac/net2cog/issues/86): Data variables not found in the input granule now log a warning instead of throwing a service error

--- a/net2cog/netcdf_convert.py
+++ b/net2cog/netcdf_convert.py
@@ -114,7 +114,7 @@ def _write_cogtiff(
                     f'{variable_path} does not have spatial dimensions such as '
                     'lat/lon, x/y, latitude/longitude, x-dim/y-dim, or XDim/YDim',
                 )
-            nc_xarray[variable_path].rio.to_raster(temp_file_name)
+            nc_xarray[variable_path].rio.to_raster(temp_file_name, BIGTIFF='IF_SAFER')
         except KeyError:
             # Occurs when trying to locate a variable that is not in the DataTree
             logger.warning(
@@ -151,24 +151,19 @@ def _write_cogtiff(
                                               logger,
                                               temp_file_name)
 
-        # Option to add additional GDAL config settings
-        # config = dict(GDAL_NUM_THREADS='ALL_CPUS', GDAL_TIFF_OVR_BLOCKSIZE='128')
-        # with rasterio.Env(**config):
-
         logger.info('Starting conversion... %s', output_file_name)
 
         with rasterio.open(temp_file_name, mode='r+') as src_dataset:
-            # if src_dst.crs is None:
-            #     src_dst.crs = crs
             src_dataset.crs = get_crs_from_grid_mapping(
                 nc_xarray, variable_path, logger
             )
             dst_profile = cog_profiles.get('deflate')
+            dst_profile.update({'BIGTIFF': 'IF_SAFER'})
             cog_translate(
                 src_dataset,
                 output_file_name,
                 dst_profile,
-                use_cog_driver=True
+                use_cog_driver=True,
             )
 
     logger.info('Finished conversion, writing variable: %s', output_file_name)
@@ -306,7 +301,7 @@ def process_value_error_exception(
         # net2cog issue #8: since we work with DataArray instead of DataTree
         # the error handler has been updated accordingly
         variable_data = value_error_handler(nc_xarray, variable_path)
-        variable_data.rio.to_raster(temp_file_name)
+        variable_data.rio.to_raster(temp_file_name, BIGTIFF='IF_SAFER')
     except ValueError as valerr:
         raise ValueError(valerr) from valerr
     except Exception as err:    # pylint: disable=broad-except
@@ -343,7 +338,7 @@ def process_invalid_dimension_order_exception(
     try:
         # reorder_dimensions now returns DataArray directly
         variable_data = reorder_dimensions(nc_xarray, variable_path)
-        variable_data.rio.to_raster(temp_file_name)
+        variable_data.rio.to_raster(temp_file_name, BIGTIFF='IF_SAFER')
     except Exception as err:    # pylint: disable=broad-except
         logger.info('Variable %s cannot be converted to tif: %s',
                     variable_path, err)
@@ -382,7 +377,7 @@ def process_dimension_error_exception(
     """
     try:
         nc_xarray_tmp = _rioxr_swapdims(nc_xarray)
-        nc_xarray_tmp[variable_path].rio.to_raster(temp_file_name)
+        nc_xarray_tmp[variable_path].rio.to_raster(temp_file_name, BIGTIFF='IF_SAFER')
     except Exception as err:    # pylint: disable=broad-except
         logger.info('Variable %s cannot be converted to tif: %s',
                     variable_path, err)
@@ -423,7 +418,7 @@ def process_missing_spatial_dimension_error_exception(
         # Both functions now return DataArray directly
         variable_data = reorder_dimensions(nc_xarray, variable_path)
         variable_data = rename_dimensions(variable_data)
-        variable_data.rio.to_raster(temp_file_name)
+        variable_data.rio.to_raster(temp_file_name, BIGTIFF='IF_SAFER')
     except Exception as err:    # pylint: disable=broad-except
         logger.info('Variable %s cannot be converted to tif: %s',
                     variable_path, err)

--- a/tests/test_netcdf_convert.py
+++ b/tests/test_netcdf_convert.py
@@ -7,11 +7,14 @@ Test the netcdf conversion functionality.
 """
 import re
 import pathlib
+import struct
 from os.path import basename, splitext
+from unittest.mock import patch
 from rio_cogeo.cogeo import cog_validate, cog_info
 
 import numpy as np
 import pytest
+import rasterio
 import xarray as xr
 
 from net2cog.netcdf_convert import (
@@ -684,3 +687,76 @@ def test_process_missing_spatial_dimension_error_catch_exception(
             str(test_file),
         )
 
+
+def test_write_cogtiff_generates_bigtiff_for_large_datatree(temp_dir, logger):
+    """Verify that _write_cogtiff generates a BigTIFF output for a large DataTree.
+
+    _write_cogtiff always passes BIGTIFF='IF_SAFER' to cog_translate. GDAL
+    uses BigTIFF format when the uncompressed raster would exceed ~4 GB (e.g.
+    a 33 000 × 33 000 float32 raster ≈ 4.3 GB). Allocating that much data in
+    a unit test is impractical, so cog_translate is mocked to:
+
+      1. Capture and assert that BIGTIFF='IF_SAFER' is present in the
+         destination profile, confirming the mechanism is correctly wired.
+      2. Write a real BigTIFF output file, simulating the format GDAL's
+         IF_SAFER would produce for a sufficiently large input dataset.
+
+    The TIFF magic number in the output file is then inspected to confirm
+    BigTIFF format (magic == 43) rather than standard TIFF (magic == 42).
+    """
+    n = 100
+    test_datatree = xr.DataTree(
+        dataset=xr.Dataset(
+            data_vars={
+                'sst': (['y', 'x'], np.zeros((n, n), dtype='float32')),
+            },
+            coords={
+                'y': ('y', np.linspace(-90, 90, n)),
+                'x': ('x', np.linspace(-180, 180, n)),
+            },
+        )
+    )
+
+    captured_profile = {}
+
+    def _mock_cog_translate(src_dataset, output_path, dst_profile, **_):
+        """Capture the destination profile and write a real BigTIFF output."""
+        captured_profile.update(dst_profile)
+        # write a bigtiff even though it's not 4.6 GB
+        with rasterio.open(
+            output_path, 'w',
+            driver='GTiff',
+            height=src_dataset.height,
+            width=src_dataset.width,
+            count=src_dataset.count,
+            dtype=src_dataset.dtypes[0],
+            crs=src_dataset.crs,
+            transform=src_dataset.transform,
+            BIGTIFF='YES',
+        ) as dst:
+            dst.write(src_dataset.read())
+
+    with patch('net2cog.netcdf_convert.cog_translate', side_effect=_mock_cog_translate):
+        output_path = _write_cogtiff(temp_dir, test_datatree, 'sst', logger)
+
+    assert output_path is not None, 'No output file was generated.'
+    assert pathlib.Path(output_path).is_file(), 'Output file does not exist.'
+
+    # Verify that _write_cogtiff passed BIGTIFF='IF_SAFER' to cog_translate.
+    # This is the parameter that causes GDAL to produce BigTIFF for large data.
+    assert captured_profile.get('BIGTIFF') == 'IF_SAFER', (
+        f"Expected BIGTIFF='IF_SAFER' in cog_translate profile, "
+        f"got: {captured_profile.get('BIGTIFF')!r}"
+    )
+
+    # Verify the output file is BigTIFF format.
+    # TIFF magic number at bytes 2–3: 42 (0x2A) = standard TIFF, 43 (0x2B) = BigTIFF.
+    with open(output_path, 'rb') as fh:
+        byte_order = fh.read(2)
+        endian = '<' if byte_order == b'II' else '>'
+        magic = struct.unpack(f'{endian}H', fh.read(2))[0]
+
+    assert magic == 43, (
+        f'Expected BigTIFF (magic number 43) but got {magic}. '
+        'Output is standard TIFF, not BigTIFF.'
+    )


### PR DESCRIPTION
Github Issue: #87 

### Description

Add the ability to support BigTIFF output when reformatting very large rasters. This should not have impacts on downstream services like HyBIG since xarray and rasterio handle TIFF and BigTIFF the same way.

### Overview of work done

Use the option `BIGTIFF='IF_SAFER'` in rioxarray calls when handling output raster data, which tells the underlying GDAL RasterIO code to output the data in BigTIFF format if it determines the raster is sufficiently large, even if the final filesize comes out under the TIFF file size limit of 4.6 GB. This enables the simple case of smaller granules to still get handled with normal tiff files, but larger inputs are able to be handled as well.

### Overview of verification done

Ran unit tests and they passed

### Overview of integration done

Ran net2cog, HyBIG, and Imagenator regression tests using localhost Harmony deployment.

## PR checklist:

* [X] Linted
* [X] Updated unit tests
* [X] Updated changelog
* [X] Integration testing

_See [Pull Request Review Checklist](../CONTRIBUTING.md#reviewing) for pointers on reviewing this pull request_