### PR TITLE
Make net2cog logs less verbose.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Minor changes and dependency updates
 ### Deprecated
 ### Removed
+- Excess logging from cog_translate
 ### Fixed
 ### Security
 

--- a/net2cog/netcdf_convert.py
+++ b/net2cog/netcdf_convert.py
@@ -8,6 +8,7 @@ Functions related to converting a NetCDF file to other formats.
 """
 
 import os
+import io
 import pathlib
 from logging import Logger
 from os.path import join as path_join, basename
@@ -168,7 +169,7 @@ def _write_cogtiff(
                 output_file_name,
                 dst_profile,
                 use_cog_driver=True,
-                quiet=True,
+                progress_out=io.StringIO(),
             )
 
     logger.info('Finished conversion, writing variable: %s', output_file_name)

--- a/net2cog/netcdf_convert.py
+++ b/net2cog/netcdf_convert.py
@@ -168,6 +168,7 @@ def _write_cogtiff(
                 output_file_name,
                 dst_profile,
                 use_cog_driver=True,
+                quiet=True,
             )
 
     logger.info('Finished conversion, writing variable: %s', output_file_name)


### PR DESCRIPTION


Github Issue: #96 

### Description

The cog_translate function defaults quiet to false, which prints progress bars by default, this makes looking at the logs very difficult.


### Overview of work done

Set the quiet flag

### Overview of verification done

Run with and without the flag and look at your output logs
 
A sample request:

http://localhost:3000/C1256108792-EEDTEST/ogc-api-coverages/1.0.0/collections/parameter_vars/coverage/rangeset?forceAsync=true&label=net2cog-SPL4_SMLM&label=harmony-py&granuleId=G1256108793-EEDTEST&format=image%2Ftiff&maxResults=1&variable=%2FLand-Model-Constants_Data%2Fcell_land_fraction


### Overview of integration done


## PR checklist:

* [ ] Linted
* [ ] Updated unit tests
* [X] Updated changelog
* [ ] Integration testing

_See [Pull Request Review Checklist](../CONTRIBUTING.md#reviewing) for pointers on reviewing this pull request_